### PR TITLE
Datadog reporting; moved out mocha hooks and external params

### DIFF
--- a/core/browser.js
+++ b/core/browser.js
@@ -7,11 +7,12 @@ import { configDesktop, configMobile } from '../settings/lighthouse.js';
 import * as os from 'os';
 
 class LighthouseBrowser {
+  static DEFAULT_TIMEOUT = 30000;
   browser;
   page;
   flow;
 
-  constructor(browserType="desktop", headless=false, browserLocation=os.type()) {
+  constructor(browserType = "desktop", headless = false, browserLocation = os.type()) {
     this.browserType = browserType;
     this.headless = headless;
     this.browserLocation = browserLocation;
@@ -20,26 +21,26 @@ class LighthouseBrowser {
   async init() {
     this.headless ? logger.debug(`[${this.browserType.toUpperCase()}] Starting HEADLESS browser (${this.browserLocation})`) : logger.debug(`[${this.browserType.toUpperCase()}] Starting HEADFUL browser (${this.browserLocation})`)
     switch (this.browserType) {
-        case "mobile": {
-            this.browser = await puppeteer.launch(this.headless ? new Browser(this.browserLocation).headlessMobile : new Browser(this.browserLocation).headfulMobile);
-            break;
-        }
-        case "desktop": {
-            this.browser = await puppeteer.launch(this.headless ?  new Browser(this.browserLocation).headlessDesktop : new Browser(this.browserLocation).headfulDesktop);
-            break;
-        }
-        default: {
-            throw new Error('browserType is not correct! Needs to be mobile or desktop, received: ' + browserType);
-        }
+      case "mobile": {
+        this.browser = await puppeteer.launch(this.headless ? new Browser(this.browserLocation).headlessMobile : new Browser(this.browserLocation).headfulMobile);
+        break;
+      }
+      case "desktop": {
+        this.browser = await puppeteer.launch(this.headless ? new Browser(this.browserLocation).headlessDesktop : new Browser(this.browserLocation).headfulDesktop);
+        break;
+      }
+      default: {
+        throw new Error('browserType is not correct! Needs to be mobile or desktop, received: ' + browserType);
+      }
     }
   }
 
   async start() {
     this.page = await this.browser.newPage();
-    if (! this.flow) {
-        await this.startNewLighthouseFlow();
+    if (!this.flow) {
+      await this.startNewLighthouseFlow();
     } else {
-        await this.updateLighthouseFlow();
+      await this.updateLighthouseFlow();
     }
   }
 
@@ -48,10 +49,10 @@ class LighthouseBrowser {
     await this.page.close();
     await this.browser.close();
     try {
-        // ensure that your system/docker has these commands installed
-        exec("kill -9 $(ps -ef | grep chrome | awk '{print $2}')");
+      // ensure that your system/docker has these commands installed
+      exec("kill -9 $(ps -ef | grep chrome | awk '{print $2}')");
     } catch (error) {
-        logger.debug("BROWSER KILLED (error was from non-existent PID, but we catch it)");
+      logger.debug("BROWSER KILLED (error was from non-existent PID, but we catch it)");
     }
     this.init()
     this.start()
@@ -59,7 +60,7 @@ class LighthouseBrowser {
 
   async startNewLighthouseFlow() {
     //this.flow = await startFlow(this.page, this.browserType === "mobile" ? new LightHouse().configMobile : new LightHouse().configDesktop);
-    this.flow = await startFlow(this.page, this.browserType === "mobile" ? {config: configMobile,} : {config: configDesktop,});
+    this.flow = await startFlow(this.page, this.browserType === "mobile" ? { config: configMobile, } : { config: configDesktop, });
     //logger.debug("[FLOW] " + JSON.stringify(this.flow));
   }
 
@@ -69,27 +70,27 @@ class LighthouseBrowser {
 
   async getNewPageWhenLoaded() {
     return new Promise(x =>
-        this.browser.on('targetcreated', async target => {
-            if (target.type() === 'page') {
-                const newPage = await target.page();
-                const newPagePromise = new Promise(y =>
-                    newPage.once('domcontentloaded', () => y(newPage))
-                );
-                const isPageLoaded = await newPage.evaluate(() => document.readyState);
-                newPage.isSuccess = true;
-                newPagePromise.isSuccess = true;
-                return isPageLoaded.match('complete|interactive') ?
-                    x(newPage) :
-                    x(newPagePromise);
-            }
-        })
+      this.browser.on('targetcreated', async target => {
+        if (target.type() === 'page') {
+          const newPage = await target.page();
+          const newPagePromise = new Promise(y =>
+            newPage.once('domcontentloaded', () => y(newPage))
+          );
+          const isPageLoaded = await newPage.evaluate(() => document.readyState);
+          newPage.isSuccess = true;
+          newPagePromise.isSuccess = true;
+          return isPageLoaded.match('complete|interactive') ?
+            x(newPage) :
+            x(newPagePromise);
+        }
+      })
     );
   }
 
-  async coldNavigation(name, link) {
+  async coldNavigation(name, link, timeout = this.DEFAULT_TIMEOUT) {
     logger.debug(`[COLDNAV] Start:${name}`);
     if (!link) {
-        link = this.page.url();
+      link = this.page.url();
     }
     try {
       await this.flow.navigate(link, { name: name });
@@ -97,27 +98,27 @@ class LighthouseBrowser {
       throw new Error(error);
     }
     logger.debug(`[COLDNAV] End:${name}`);
-    await this.waitTillRendered();
+    await this.page.waitForTimeout(timeout);
   }
 
-  async warmNavigation(name, link) {
+  async warmNavigation(name, link, timeout = this.DEFAULT_TIMEOUT) {
     logger.debug(`[WARMNAV] Start:${name}`);
     if (!link) {
-        link = this.page.url();
+      link = this.page.url();
     }
-    await this.flow.navigate(link, { name: name, configContext: {settingsOverrides: {disableStorageReset: true}}});
+    await this.flow.navigate(link, { name: name, configContext: { settingsOverrides: { disableStorageReset: true } } });
     logger.debug(`[WARMNAV] End:${name}`);
+    await this.page.waitForTimeout(timeout);
+  }
+
+  async goToPage(link, timeout = this.DEFAULT_TIMEOUT) {
+    logger.debug(`[GOTOPAGE] ${link}`);
+    await this.page.goto(link);
+    await this.page.waitForTimeout(timeout);
     await this.waitTillRendered();
   }
 
-  async goToPage(link) {
-    logger.debug(`[GOTOPAGE] ${link}`);
-    await this.page.goto(link);
-    await this.page.waitForTimeout(10000);
-    await this.waitTillRendered(); 
-  }
-
-  async waitTillRendered(timeout = 30000) {
+  async waitTillRendered(timeout = this.DEFAULT_TIMEOUT) {
     const checkDurationMsecs = 1000;
     const maxChecks = timeout / checkDurationMsecs;
     let lastHTMLSize = 0;
@@ -125,27 +126,35 @@ class LighthouseBrowser {
     let countStableSizeIterations = 0;
     const minStableSizeIterations = 3;
 
-    while(checkCounts++ <= maxChecks) {
-        let html = await this.page.content();
-        let currentHTMLSize = html.length;
+    while (checkCounts++ <= maxChecks) {
+      let html = "PAGE UNKNOWN"
+      try {
+        html = await page.content();
+      }
+      catch (error) {
+        console.log(error)
+        break;
+      }
 
-        if(lastHTMLSize != 0 && currentHTMLSize == lastHTMLSize) {
-            countStableSizeIterations++;
-        } else {
-            countStableSizeIterations = 0; //reset the counter
-        }
+      let currentHTMLSize = html.length;
 
-        if(countStableSizeIterations >= minStableSizeIterations) {
-            logger.debug(`[SUCCESS] Fully Rendered Page: ${this.page.url()}`);
-            break;
-        }
+      if (lastHTMLSize != 0 && currentHTMLSize == lastHTMLSize) {
+        countStableSizeIterations++;
+      } else {
+        countStableSizeIterations = 0; //reset the counter
+      }
 
-        lastHTMLSize = currentHTMLSize;
-        await this.page.waitForTimeout(checkDurationMsecs);
+      if (countStableSizeIterations >= minStableSizeIterations) {
+        logger.debug(`[SUCCESS] Fully Rendered Page: ${this.page.url()}`);
+        break;
+      }
+
+      lastHTMLSize = currentHTMLSize;
+      await this.page.waitForTimeout(checkDurationMsecs);
     }
   }
 
-  async closeBrowser(browser) {
+  async closeBrowser() {
     logger.debug('CLOSING BROWSER');
     await this.browser.close();
   }

--- a/core/elements/button.js
+++ b/core/elements/button.js
@@ -37,7 +37,7 @@ export default class Button extends Element {
     }
 
     // Action: double click on button using Puppeteer double click
-    async dobleClick(timeout=Element.DEFAULT_TIMEOUT){
+    async doubleClick(timeout=Element.DEFAULT_TIMEOUT){
         logger.debug(`[DOUBLECLICK] ${this.locatorType}:${this.locator}`);
         try {
             await this.find(timeout);

--- a/reporting/createReport.js
+++ b/reporting/createReport.js
@@ -1,19 +1,108 @@
-import logger from "../logger/logger.js";
 import fs from 'fs/promises';
+import https from 'https';
+import logger from "../logger/logger.js";
 
-// need to write to the parent directory for Carrier
 const reportPath = './user-flow.report.html';
 const reportPathJson = './user-flow.report.json';
+const performanceAudits = [
+  'first-contentful-paint',
+  'speed-index',
+  'interactive',
+  'interaction-to-next-paint',
+  'total-blocking-time',
+  'largest-contentful-paint',
+  'cumulative-layout-shift',
+  'mainthread-work-breakdown',
+  'network-requests',
+];
 
 export default class CreateReport {
-    async createReports(flow, configString) {
-      //use configString to add mobile/desktop to report name (will fail in Carrier)
-      const reportHTML = await flow.generateReport();
-      // const reportJSON = JSON.stringify(flow.getFlowResult()).replace(/</g, '\\u003c').replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029'); // For LH @9.2.0
-      const reportJSON = JSON.stringify(await flow.createFlowResult(), null, 2); // For LH newer than @9.2.0
-      await fs.writeFile(reportPath, reportHTML);
-      await fs.writeFile(reportPathJson, reportJSON);
-      logger.debug("[REPORT] HTML path: " + reportPath);
-      logger.debug("[REPORT] JSON path: " + reportPathJson);
+  constructor(ddHost, ddKey) {
+    this.ddHost = ddHost;
+    this.ddKey = ddKey;
+  }
+
+  async createReports(flow) {
+    const reportHTML = await flow.generateReport();
+    const flowResult = await flow.createFlowResult();
+    const reportJSON = JSON.stringify(flowResult, null, 2);
+
+    await fs.writeFile(reportPath, reportHTML);
+    await fs.writeFile(reportPathJson, reportJSON);
+
+    logger.debug("[REPORT] HTML path: " + reportPath);
+    logger.debug("[REPORT] JSON path: " + reportPathJson);
+
+    if (this.ddHost && this.ddKey) {
+      await this.sendMetricsToDD(flowResult);
+    } else {
+      logger.debug("[REPORT] Datadog API host or API key not provided. Skipping sending metrics");
     }
+  }
+
+  async sendMetricsToDD(flowResult) {
+    logger.debug("[REPORT] Sending metrics to Datadog...");
+    const now = Math.floor(Date.now() / 1000);
+    try {
+      const metricsToSend = flowResult.steps.flatMap(step => {
+        const metrics = [];
+        const applicationName = this.extractApplicationName(step.lhr.finalDisplayedUrl);
+        const performanceScore = step.lhr.categories.performance.score * 100;
+
+        metrics.push({
+          metric: 'website.performance.score',
+          points: [[now, performanceScore]],
+          type: 'gauge',
+          tags: [`step_name:${step.name}`, `application_name:${applicationName}`, 'environment:test']
+        });
+
+        for (const audit of performanceAudits) {
+          const numericValue = step.lhr.audits[audit]?.numericValue;
+          if (numericValue != null) {
+            metrics.push({
+              metric: `website.performance.${audit.replace('-', '_')}`,
+              points: [[now, numericValue]],
+              type: 'gauge',
+              tags: [`step_name:${step.name}`, `application_name:${applicationName}`, 'environment:test']
+            });
+          }
+        }
+
+        return metrics;
+      });
+
+      const options = {
+        hostname: this.ddHost,
+        path: '/api/v1/series',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'DD-API-KEY': this.ddKey
+        }
+      };
+
+      const req = https.request(options, res => {
+        res.on('data', d => process.stdout.write(d));
+      });
+
+      req.on('error', e => {
+        logger.debug("[REPORT] Error sending metrics to Datadog: " + e.message);
+      });
+
+      req.write(JSON.stringify({ series: metricsToSend }));
+      req.end();
+    } catch (error) {
+      logger.debug(`[REPORT] Error sending metrics to Datadog: ${error}`);
+    }
+  }
+
+  extractApplicationName(url) {
+    try {
+      const urlObj = new URL(url);
+      return urlObj.hostname ? urlObj.hostname.split('.')[0] : '3rd-party';
+    } catch (e) {
+      logger.debug(e);
+      return '3rd-party';
+    }
+  }
 }

--- a/settings/mochaHooks.js
+++ b/settings/mochaHooks.js
@@ -1,0 +1,37 @@
+import logger from "../logger/logger.js";
+import CreateReport from '../reporting/createReport.js';
+import * as params from './testParams.js';
+import { setupBrowser } from './testParams.js';
+
+let browser;
+export async function beforeHook() {
+    browser = await setupBrowser();
+};
+
+// Check if prev flow finished successfully before launching test
+export async function beforeEachHook() {
+    logger.debug("[STARTED] " + this.currentTest.fullTitle());
+    this.timeout(params.testTime);
+    if (browser.flow.currentTimespan) {  // happens if waiting inside actions exceeds "params.testTime" timeout
+        await browser.flow.endTimespan() // stopping active timespan if not stopped by timeout
+        browser.page.isSuccess = false
+        throw new Error('Skipping test because previous flow exceeded testTime limit: ' + params.testTime);
+    }
+    else if (!browser.page.isSuccess)
+        throw new Error('Skipping test because previous flow failed');
+};
+
+export async function afterEachHook() {
+    logger.debug("[ENDED] " + this.currentTest.title);
+};
+
+export async function afterHook() {
+    this.timeout(300000); // consider increasing this time if it can't create report within the limit
+    if (browser.flow.currentTimespan) {  // happens if waiting inside actions exceeds "testTime" timeout
+        await browser.flow.endTimespan(); // stopping active timespan if not stopped by timeout
+        browser.page.isSuccess = false;
+    }
+    await browser.flow.snapshot({ name: 'Capturing last state of the test' });
+    await new CreateReport(params.ddHost,params.ddKey).createReports(browser.flow);
+    await browser.closeBrowser();
+};

--- a/settings/testParams.js
+++ b/settings/testParams.js
@@ -1,0 +1,55 @@
+import LighthouseBrowser from '../core/browser.js';
+import path from 'path';
+import * as os from 'os';
+
+let browserInstance;
+const args = process.argv;
+const uploadDir = path.dirname(new URL(import.meta.url).pathname);
+
+// Sets duration for all "it" mocha methods
+const testTime = 120000;
+
+// Define constants for input arguments
+const browserType = args.includes("--desktop") ? "desktop" : "mobile";
+const headless = args.includes("--headless");
+const browserLocationIndex = args.indexOf("--browserLocation");
+const testuserIndex = args.indexOf("--login");
+const testpasswordIndex = args.indexOf("--password");
+const envIndex = args.indexOf("--host");
+const ddHostIndex = args.indexOf("--ddhost");
+const ddKeyIndex = args.indexOf("--ddkey");
+const browserLocation = browserLocationIndex !== -1 ? args[browserLocationIndex + 1] : os.type();
+const login = testuserIndex !== -1 ? args[testuserIndex + 1] : undefined;
+const password = testpasswordIndex !== -1 ? args[testpasswordIndex + 1] : undefined;
+const url = envIndex !== -1 ? args[envIndex + 1] : undefined;
+const ddHost = ddHostIndex !== -1 ? args[ddHostIndex + 1] : undefined;
+const ddKey = ddKeyIndex !== -1 ? args[ddKeyIndex + 1] : undefined;
+
+async function setupBrowser() {
+    if (!browserInstance) {
+        browserInstance = new LighthouseBrowser(browserType, headless, browserLocation);
+        await browserInstance.init();
+        await browserInstance.start();
+    }
+    return browserInstance;
+}
+
+async function getBrowserInstance() {
+    if (!browserInstance) {
+        throw new Error('Browser not initialized. Call setupBrowser first.');
+    }
+    return browserInstance;
+}
+
+export {
+    setupBrowser,
+    getBrowserInstance,
+    browserType,
+    testTime,
+    uploadDir,
+    login,
+    password,
+    url,
+    ddHost,
+    ddKey
+};


### PR DESCRIPTION
# Supported Datadog Reporting

Run your Docker container with the following command to enable Datadog reporting:

```bash
docker run --rm -v "$PWD:$PWD" -w "$PWD" ibombit/lighthouse-puppeteer-chrome:11.1.0-alpine npx mocha ${{ secrets.TEST_PATH }} --desktop --headless --host ${{ secrets.HOST }} --login ${{ secrets.USER }} --password ${{ secrets.PSWRD }} --ddhost ${{ secrets.DDHOST }} --ddkey ${{ secrets.DDKEY }}
```

The **`--ddhost`** and **`--ddkey`** arguments require your Datadog host and API key, respectively.

## Reusable Mocha Hooks

Common "before everything" hooks have been moved out for reusability across tests. You can override the default hooks as shown in the following example:

![Mocha Hook Override Example](https://github.com/iBombit/lighthouse_custom/assets/65038584/a4fba865-f105-42f6-aa0b-4564f2998ef1)

## Standardized Test Parameters

For convenience, frequently used test parameters are predefined:

- **`--desktop`**  
  Specifies a desktop view. If omitted, a mobile view is used by default.

- **`--headless`**  
  Runs tests in headless mode. If omitted, a browser window will open.

- **`--browserLocation`**  
  Sets a custom browser location. Usage: `--browserLocation "C:/Browser/start.exe"`

- **`--login`**  
  Sets the login. Usage: `--login example@email.com`

- **`--password`**  
  Sets the password. Usage: `--password PASSWORD`

- **`--host`**  
  Sets the host link. Usage: `--host https://google.com`

- **`--ddhost`**  
  Specifies the Datadog host link (exclude 'https://'). Usage: `--ddhost api.datadoghq.eu`

- **`--ddkey`**  
  Provides the Datadog API key. Usage: `--ddkey <Your_Datadog_API_Key>`