### PR TITLE
1.2.0 navigation flow breaking changes

### DIFF
--- a/core/browser.js
+++ b/core/browser.js
@@ -65,6 +65,7 @@ class LighthouseBrowser {
         page.init(this.page); // Sets instance of puppeteer page to page objects
       }
     }
+    await new Promise(resolve => setTimeout(resolve, 10000)); // Assuming 10sec is enough to launch the browser
     return this
   }
 
@@ -97,27 +98,19 @@ class LighthouseBrowser {
     );
   }
 
-  async coldNavigation(name, link, timeout = LighthouseBrowser.DEFAULT_TIMEOUT) {
-    if (!link) {
-      link = this.page.url();
-    }
+  async navigation(name, link, pages) {
+    if (pages) await this.restartBrowser(pages)
+    if (!link) link = this.page.url();
     try {
-      await this.flow.navigate(link, { name: name });
+      await this.flow.navigate(link, { name: name, configContext: { settingsOverrides: { disableStorageReset: true } } });
     } catch (error) {
       throw new Error(error);
     }
-    await this.waitTillRendered(timeout);
+    return this;
   }
 
-  async warmNavigation(name, link, timeout = LighthouseBrowser.DEFAULT_TIMEOUT) {
-    if (!link) {
-      link = this.page.url();
-    }
-    await this.flow.navigate(link, { name: name, configContext: { settingsOverrides: { disableStorageReset: true } } });
-    await this.waitTillRendered(timeout);
-  }
-
-  async customNavigation(stepName, actions) {
+  async customNavigation(stepName, actions, pages) {
+    if (pages) await this.restartBrowser(pages)
     await this.flow.startNavigation({ name: stepName })
     await actions();
     await this.flow.endNavigation()

--- a/core/page.js
+++ b/core/page.js
@@ -1,7 +1,5 @@
 import * as params from 'lh-pptr-framework/settings/testParams.js';
-import Button from 'lh-pptr-framework/core/elements/button.js';
-import TextField from 'lh-pptr-framework/core/elements/textField.js';
-import UploadField from 'lh-pptr-framework/core/elements/uploadField.js';
+import logger from "lh-pptr-framework/logger/logger.js";
 
 export default class Page {
     static baseUrl = params.url;
@@ -14,68 +12,70 @@ export default class Page {
         this.p.isSuccess = true;
     }
 
-    /** Register button @name located by @selector */
-    btn(name, selector) {
-        this[name] = new Button(selector, this.p);
-        return this[name]
-    }
-
-    /** Register input @name located by @selector */
-    input(name, selector) {
-        this[name] = new TextField(selector, this.p);
-        return this[name]
-    }
-
-    /** Register upload input @name located by @selector */
-    upload(name, selector) {
-        this[name] = new UploadField(selector, this.p);
-        return this[name]
-    }
-
     /**
      * @async
-     * @function coldNavigation
+     * @function navigation
      * @param {object} browser - The browser instance.
+     * @param {object} testContext - The Mocha test context (this).
      * @param {string} [link=this.getURL()] - The URL to navigate to.
-     * @param {number} [timeout=this.DEFAULT_TIMEOUT] - The maximum time to wait for navigation to complete. 
-     * @throws {Error} Throws an error if navigation fails.
-     * @example
-     * // Given: I am opening the browser
-     * // When: I am navigating to the Home page
-     * // Then: I measure cold navigation performance of the page
-     * await SomePage.coldNavigation(browser, 'https://example.com/home');
-     */
-    async coldNavigation(browser, link = this.getURL(), timeout = this.DEFAULT_TIMEOUT) {
-        await browser.coldNavigation(`${this.constructor.name} - cold`, link, timeout)
-    }
-
-    /**
-     * @async
-     * @function warmNavigation
-     * @param {object} browser - The browser instance.
-     * @param {string} [link=this.getURL()] - The URL to navigate to.
-     * @param {number} [timeout=this.DEFAULT_TIMEOUT] - The maximum time to wait for navigation to complete.
+     * @param {object} pages - Instance of all page objects to reinitialize after restart.
      * @throws {Error} - Throws an error if the navigation process fails.
      * @example
      * // Given: I am already on a website with some resources cached
-     * // When: I am navigating to another page on the same website
+     * // When: I am restarting browser and navigating to another page on the same website
      * // Then: I measure warm navigation performance of the page
-     * await SomePage.warmNavigation(browser, 'https://example.com/home');
+     * await SomePage.navigation(this, browser, 'https://example.com/home', pages);
      */
-    async warmNavigation(browser, link = this.getURL(), timeout = this.DEFAULT_TIMEOUT) {
-        await browser.warmNavigation(`${this.constructor.name} - warm`, link, timeout)
+    async navigation(browser, testContext, link = this.getURL(), pages) {
+        const stepName = testContext?.test?.title || `[N]_${this.constructor.name}`;
+        browser = await browser.navigation(stepName, link, pages)
+        return browser;
     }
+
+    /**
+     * @async
+     * @function navigationValidate
+     * @param {object} browser - The browser instance.
+     * @param {object} testContext - The Mocha test context (this).
+     * @param {string} [link=this.getURL()] - The URL to navigate to.
+     * @param {object} pages - Instance of all page objects to reinitialize after restart.
+     * @throws {Error} - Throws an error if the navigation process fails.
+     * @example
+     * // Navigate to a page and validate it loaded correctly with pageValidate selector.
+     * // Ensure that the pageValidate element is defined in the page object.
+     * await SomePage.navigationValidate(browser, this, 'https://example.com/home', pages);
+     */
+    async navigationValidate(browser, testContext, link = this.getURL(), pages) {
+        const stepName = testContext?.test?.title || `[N]_${this.constructor.name}`;
+        browser = await browser.navigation(stepName, link, pages);
+        try {
+            if (this.pageValidate) {
+                await this.pageValidate.find(5000);
+                await browser.flow.snapshot({ name: stepName.replace('[N]_', '[S]_') + '_SUCCESS' });
+            }
+            else {
+                logger.debug("[ERROR] Page validation element is not defined in the page object, snaphot checking is skipped.");
+            }
+        } catch (error) {
+            await browser.flow.snapshot({ name: stepName.replace('[N]_', '[S]_') + '_FAILED' });
+            throw new Error(`Page validation failed for ${link}: ${error.message}`);
+        }
+        return browser;
+    }
+
     /**
      * @async
      * @function openURL
-     * @param {number} [timeout=this.DEFAULT_TIMEOUT] - The target URL for navigation. If not provided, defaults to the current page URL.
+     * @param {object} browser - The browser instance.
+     * @param {string} [link=this.getURL()] - The URL to navigate to. If not provided, defaults to the current page URL.
+     * @param {number} [timeout=30000] - The timeout for navigation.
      * @throws {Error} When the browser is unable to navigate to the specified URL within the given timeout period.
      * @example
-     * // Example usage: Navigating to the homepage with a custom timeout value
-     * await SomePage.openURL(browser, 5000);
+     * // Example usage: Simple navigation to a page without Lighthouse measurement
+     * await SomePage.openURL(browser, 'https://example.com/home', 5000);
      */
-    async openURL(browser, timeout = this.DEFAULT_TIMEOUT) {
-        await browser.goToPage(this.getURL(), timeout)
+    async openURL(browser, link = this.getURL(), timeout = 30000) {
+        await browser.goToPage(link, timeout)
     }
 
     setPath(path = '') {
@@ -87,8 +87,4 @@ export default class Page {
         return `${Page.baseUrl.replace(/\/+$/, '')}/${this.path.replace(/^\/+/, '')}`;
     }
 
-    /** Action: close page */
-    async close() {
-        await this.p.close();
-    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lh-pptr-framework",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Customizable framework for UI testing multiple pages/SPA actions within a single Lighthouse report",
   "author": "Sergei Pashkevich",
   "license": "ISC",


### PR DESCRIPTION
## Changelog

### 🚀 **Enhanced Framework Features**

#### **Page Class Enhancements**

##### **Mocha Test Integration**
- **Added Mocha test context support**: Enhanced `navigation()` method to accept test context as second parameter
  - **New signature**: `navigation(browser, testContext, link, pages)`
  - **Automatic test naming**: Uses `testContext.test.title` for Lighthouse step names
  - **Fallback naming**: Uses `[N]_${this.constructor.name}` when no test context provided
  - **Location**: page.js lines ~27-32

##### **Browser Restart Functionality**
- **Added `pages` parameter**: When provided, triggers browser restart and automatic page object re-initialization
  - **New behavior**: Passing `pages` array automatically:
    - Kills current browser instance
    - Starts fresh browser instance  
    - Re-initializes all page objects with new browser context
    - Ensures clean state for performance measurements
  - **Use case**: Essential for "cold navigation" tests that require fresh browser state
  - **Example**: `await SomePage.navigation(browser, this, url, [page1, page2])`

##### **New Validation Method**
- **Added `navigationValidate()` method**: Navigate with automatic page validation and snapshot capture
  - **Features**: 
    - Performs navigation followed by validation using `pageValidate` selector
    - Captures SUCCESS snapshot if validation passes
    - Captures FAILED snapshot if validation fails
    - Uses `[S]_` prefix for snapshots to distinguish from navigation steps
  - **Location**: page.js lines ~42-57

---

### 📋 **Migration Guide**

#### **For existing tests using `navigation()`:**
```javascript
// Before
await SomePage.coldNavigation(browser, url)

// After  
await SomePage.navigation(browser, this, url)
```