### PR TITLE
[1.3.4] support onlyCategories in customConfig.json with mode-aware filtering

### DIFF
--- a/core/browser.js
+++ b/core/browser.js
@@ -3,7 +3,7 @@ import logger from "lh-pptr-framework/logger/logger.js";
 import { Browser } from 'lh-pptr-framework/settings/browser.js';
 import { startFlow } from 'lighthouse/core/index.js';
 import { exec } from 'child_process';
-import { getLighthouseConfigByBrowserType } from 'lh-pptr-framework/settings/configLoader.js';
+import { getLighthouseConfigByBrowserType, getOnlyCategories, getOnlyCategoriesForMode } from 'lh-pptr-framework/settings/configLoader.js';
 import * as os from 'os';
 
 class LighthouseBrowser {
@@ -102,7 +102,10 @@ class LighthouseBrowser {
     if (pages) await this.restartBrowser(pages)
     if (!link) link = this.page.url();
     try {
-      await this.flow.navigate(link, { name: name, configContext: { settingsOverrides: { disableStorageReset: true } } });
+      const flags = { name: name, configContext: { settingsOverrides: { disableStorageReset: true } } };
+      const onlyCategories = getOnlyCategories();
+      if (onlyCategories) flags.onlyCategories = onlyCategories;
+      await this.flow.navigate(link, flags);
     } catch (error) {
       throw new Error(error);
     }
@@ -111,15 +114,27 @@ class LighthouseBrowser {
 
   async customNavigation(stepName, actions, pages) {
     if (pages) await this.restartBrowser(pages)
-    await this.flow.startNavigation({ name: stepName })
+    const flags = { name: stepName };
+    const onlyCategories = getOnlyCategories();
+    if (onlyCategories) flags.onlyCategories = onlyCategories;
+    await this.flow.startNavigation(flags)
     await actions();
     await this.flow.endNavigation()
   }
 
   async timespan(stepName, actions) {
-    await this.flow.startTimespan({ name: stepName })
+    const flags = { name: stepName };
+    const onlyCategories = getOnlyCategories();
+    if (onlyCategories) flags.onlyCategories = onlyCategories;
+    await this.flow.startTimespan(flags)
     await actions();
     await this.flow.endTimespan()
+  }
+
+  async snapshot(flags = {}) {
+    const onlyCategories = getOnlyCategoriesForMode('snapshot');
+    if (onlyCategories) flags.onlyCategories = onlyCategories;
+    await this.flow.snapshot(flags);
   }
 
   async goToPage(link, timeout = LighthouseBrowser.DEFAULT_TIMEOUT) {

--- a/core/page.js
+++ b/core/page.js
@@ -81,9 +81,9 @@ export default class Page {
         // Take snapshots after navigation is complete
         try {
             if (validationSuccessful) {
-                await browser.flow.snapshot({ name: stepName.replace('[N]_', '[S]_') + '_SUCCESS' });
+                await browser.snapshot({ name: stepName.replace('[N]_', '[S]_') + '_SUCCESS' });
             } else if (validationError) {
-                await browser.flow.snapshot({ name: stepName.replace('[N]_', '[S]_') + '_FAILED' });
+                await browser.snapshot({ name: stepName.replace('[N]_', '[S]_') + '_FAILED' });
                 throw new Error(`Page validation failed for ${link}: ${validationError.message}`);
             }
         } catch (snapshotError) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lh-pptr-framework",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Customizable framework for UI testing multiple pages/SPA actions within a single Lighthouse report",
   "author": "Sergei Pashkevich",
   "license": "ISC",

--- a/settings/configLoader.js
+++ b/settings/configLoader.js
@@ -8,6 +8,8 @@ import { Desktop, Mobile, Mobile3G, Mobile4G, Mobile4G_Slow } from 'lh-pptr-fram
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 let browserConfig = null;
+let customOnlyCategories = null;
+let configCategories = null;
 
 /**
  * Load custom config file from testParams or default location
@@ -138,14 +140,28 @@ export function getLighthouseConfigByBrowserType(browserType) {
   if (configFilePath) {
     try {
       const customConfig = JSON.parse(fs.readFileSync(path.resolve(configFilePath), 'utf-8'));
-      return {
+
+      // Extract non-lighthouse settings and onlyCategories before merging
+      const { browserArgs, onlyCategories, ...lighthouseSettings } = customConfig.settings || {};
+
+      // Store onlyCategories separately — applied per-step in browser.js
+      // to avoid conflicts with snapshot mode (which filters categories by gather mode
+      // before checking onlyCategories, causing "unrecognized category" errors)
+      customOnlyCategories = onlyCategories || null;
+
+      const mergedConfig = {
         ...baseConfig,
         ...customConfig,
         settings: {
           ...baseConfig.settings,
-          ...customConfig.settings,
+          ...lighthouseSettings,
         },
       };
+
+      // Store category definitions for mode-aware filtering
+      configCategories = mergedConfig.categories || baseConfig.categories || null;
+
+      return mergedConfig;
     } catch (error) {
       logger.error(`Failed to load custom config file: ${error.message}`);
       return baseConfig; // Fallback to base config if error occurs
@@ -153,4 +169,35 @@ export function getLighthouseConfigByBrowserType(browserType) {
   }
 
   return baseConfig; // Default config if no custom file is provided
+}
+
+/**
+ * Get onlyCategories from custom config (if specified)
+ * Used by browser.js to apply per-step category filtering for navigation/timespan steps
+ * @returns {string[]|null} Array of category IDs or null
+ */
+export function getOnlyCategories() {
+  return customOnlyCategories;
+}
+
+/**
+ * Get onlyCategories filtered for a specific gather mode.
+ * Removes categories whose supportedModes don't include the given mode.
+ * @param {string} mode - Gather mode ('navigation', 'timespan', 'snapshot')
+ * @returns {string[]|null} Filtered array of category IDs or null
+ */
+export function getOnlyCategoriesForMode(mode) {
+  if (!customOnlyCategories) return null;
+  if (!configCategories) return customOnlyCategories;
+
+  const filtered = customOnlyCategories.filter(categoryId => {
+    const category = configCategories[categoryId];
+    // If category is not in our config (e.g. a default LH category), keep it
+    if (!category) return true;
+    // If no supportedModes defined, category supports all modes
+    if (!category.supportedModes) return true;
+    return category.supportedModes.includes(mode);
+  });
+
+  return filtered.length ? filtered : null;
 }

--- a/settings/mochaHooks.js
+++ b/settings/mochaHooks.js
@@ -44,7 +44,7 @@ export async function afterHook() {
             await browser.flow.endTimespan(); // stopping the active timespan if not stopped by timeout
             browser.page.isSuccess = false;
         }
-        await browser.flow.snapshot({ name: 'Capturing last state of the test' });
+        await browser.snapshot({ name: 'Capturing last state of the test' });
         await new CreateReport().createReports(browser.flow);
         await browser.closeBrowser();
     } catch (error) {


### PR DESCRIPTION
## Problem

When `customConfig.json` includes `onlyCategories: ['performance', 'server-side']`, Lighthouse throws:
```
Error: unrecognized category in 'onlyCategories': server-side
```

This happens because `server-side` has `supportedModes: ['navigation', 'timespan']` — when `flow.snapshot()` runs, Lighthouse filters out `server-side` by gather mode **before** checking `onlyCategories`, so it becomes unrecognized.

## Solution

### configLoader.js
- Extract `onlyCategories` and `browserArgs` from custom config settings before merging into Lighthouse config (neither should leak into Lighthouse settings)
- Store category definitions for mode-aware filtering
- Export `getOnlyCategories()` — returns raw `onlyCategories` for navigation/timespan steps
- Export `getOnlyCategoriesForMode(mode)` — filters `onlyCategories` to only include categories whose `supportedModes` include the given mode

### browser.js
- Pass `onlyCategories` as per-step flags in `navigation()`, `customNavigation()`, `timespan()`
- Add `snapshot()` wrapper that applies mode-aware filtered `onlyCategories` (excludes `server-side` since it doesn't support snapshot mode)

### page.js / mochaHooks.js
- Use `browser.snapshot()` instead of `browser.flow.snapshot()` so all snapshot calls go through the mode-aware filtering