### PR TITLE
[1.3.4] updating framework version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ This parameter allows you to pass a custom JSON file to override the default Lig
       "cpuSlowdownMultiplier": 2
     },
     "formFactor": "mobile",
+    "onlyCategories": [
+      "performance",
+      "server-side"
+    ],
     "screenEmulation": {
       "mobile": true,
       "width": 375,
@@ -78,6 +82,12 @@ The `browserArgs` section allows you to customize Puppeteer browser launch argum
 
 - **headless**: Arguments used when `--headless=true`
 - **headful**: Arguments used when `--headless=false`
+
+#### Category Filtering
+
+The `onlyCategories` setting limits which Lighthouse categories appear in the report. You can include both built-in categories (`performance`, `accessibility`, `best-practices`, `seo`) and custom ones (`server-side`).
+
+Categories are automatically filtered by gather mode — for example, `server-side` only supports `navigation` and `timespan` modes, so it is excluded from snapshot steps automatically.
 
 Common browser arguments include:
 - `--no-sandbox` - Disable the sandbox

--- a/docker/v13.0.3/package-lock.json
+++ b/docker/v13.0.3/package-lock.json
@@ -13,7 +13,7 @@
         "csv-parser": "^3.2.0",
         "es-main": "^1.4.0",
         "express": "^5.2.1",
-        "lh-pptr-framework": "1.3.3",
+        "lh-pptr-framework": "1.3.4",
         "lighthouse": "^13.0.3",
         "logform": "^2.7.0",
         "mocha": "^11.7.5",
@@ -2918,9 +2918,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lh-pptr-framework": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/lh-pptr-framework/-/lh-pptr-framework-1.3.3.tgz",
-      "integrity": "sha512-s19E5Le/Q0uUrDIlP08rt9WI8SyAte4vKM9XMwdwl5eB+wY+apOa1nIbVmM4ONvjPWXxHAA9d7a9Qr2Cm/Rmjg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/lh-pptr-framework/-/lh-pptr-framework-1.3.4.tgz",
+      "integrity": "sha512-KmztTP3P97ESS/BIAa7Yod6cvx6Tn53LW9kacYtLCyKxphQuSZrfDTMAvB/R1IV7MZcpuwRJ7pBJv7n/BHxxqA==",
       "license": "ISC"
     },
     "node_modules/lighthouse": {

--- a/docker/v13.0.3/package.json
+++ b/docker/v13.0.3/package.json
@@ -10,7 +10,7 @@
     "crawl": "node crawler/crawler.js"
   },
   "dependencies": {
-    "lh-pptr-framework": "1.3.3",
+    "lh-pptr-framework": "1.3.4",
     "lighthouse": "^13.0.3",
     "puppeteer": "^24.38.0",
     "chai": "^6.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "csv-parser": "^3.2.0",
         "es-main": "^1.4.0",
         "express": "^5.2.1",
-        "lh-pptr-framework": "1.3.3",
+        "lh-pptr-framework": "1.3.4",
         "lighthouse": "^13.0.3",
         "logform": "^2.7.0",
         "mocha": "^11.7.5",
@@ -2918,9 +2918,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lh-pptr-framework": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/lh-pptr-framework/-/lh-pptr-framework-1.3.3.tgz",
-      "integrity": "sha512-s19E5Le/Q0uUrDIlP08rt9WI8SyAte4vKM9XMwdwl5eB+wY+apOa1nIbVmM4ONvjPWXxHAA9d7a9Qr2Cm/Rmjg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/lh-pptr-framework/-/lh-pptr-framework-1.3.4.tgz",
+      "integrity": "sha512-KmztTP3P97ESS/BIAa7Yod6cvx6Tn53LW9kacYtLCyKxphQuSZrfDTMAvB/R1IV7MZcpuwRJ7pBJv7n/BHxxqA==",
       "license": "ISC"
     },
     "node_modules/lighthouse": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "crawl": "node crawler/crawler.js"
   },
   "dependencies": {
-    "lh-pptr-framework": "1.3.3",
+    "lh-pptr-framework": "1.3.4",
     "lighthouse": "^13.0.3",
     "puppeteer": "^24.38.0",
     "chai": "^6.2.2",


### PR DESCRIPTION
Bump `lh-pptr-framework` dependency from `1.3.3` to `1.3.4` in:
- `package.json` + `package-lock.json`
- `docker/v13.0.3/package.json` + `docker/v13.0.3/package-lock.json`

Related framework PR: #71