### PR TITLE
[1.3.6] update framework to 1.3.6

### DIFF
--- a/docker/v13.1.0/package-lock.json
+++ b/docker/v13.1.0/package-lock.json
@@ -13,7 +13,7 @@
         "csv-parser": "^3.2.0",
         "es-main": "^1.4.0",
         "express": "^5.2.1",
-        "lh-pptr-framework": "1.3.4",
+        "lh-pptr-framework": "1.3.6",
         "lighthouse": "^13.1.0",
         "logform": "^2.7.0",
         "mocha": "^11.3.0",
@@ -1231,9 +1231,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2676,9 +2676,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2922,9 +2922,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lh-pptr-framework": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/lh-pptr-framework/-/lh-pptr-framework-1.3.4.tgz",
-      "integrity": "sha512-KmztTP3P97ESS/BIAa7Yod6cvx6Tn53LW9kacYtLCyKxphQuSZrfDTMAvB/R1IV7MZcpuwRJ7pBJv7n/BHxxqA==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/lh-pptr-framework/-/lh-pptr-framework-1.3.6.tgz",
+      "integrity": "sha512-2nGwMU6cefb1gweIVuGiLBpzDGno4HhCqHbrtNTp3zBl89ygKPyJFkLI7zRhwIiRwI956lzJdT+xMp++wHBVSA==",
       "license": "ISC"
     },
     "node_modules/lighthouse": {
@@ -3660,9 +3660,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/docker/v13.1.0/package.json
+++ b/docker/v13.1.0/package.json
@@ -14,7 +14,7 @@
     "csv-parser": "^3.2.0",
     "es-main": "^1.4.0",
     "express": "^5.2.1",
-    "lh-pptr-framework": "1.3.4",
+    "lh-pptr-framework": "1.3.6",
     "lighthouse": "^13.1.0",
     "logform": "^2.7.0",
     "mocha": "^11.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "csv-parser": "^3.2.0",
         "es-main": "^1.4.0",
         "express": "^5.2.1",
-        "lh-pptr-framework": "1.3.5",
+        "lh-pptr-framework": "1.3.6",
         "lighthouse": "^13.1.0",
         "logform": "^2.7.0",
         "mocha": "^11.3.0",
@@ -2922,9 +2922,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lh-pptr-framework": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/lh-pptr-framework/-/lh-pptr-framework-1.3.5.tgz",
-      "integrity": "sha512-9LBvzqStKjy/2oNd00vOHwsHcehs1v4u4m8WGktYVZjd0KrVQrDD//8pls7MsI6XG7a7RT6MkRuzZJ3YWCMQng==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/lh-pptr-framework/-/lh-pptr-framework-1.3.6.tgz",
+      "integrity": "sha512-2nGwMU6cefb1gweIVuGiLBpzDGno4HhCqHbrtNTp3zBl89ygKPyJFkLI7zRhwIiRwI956lzJdT+xMp++wHBVSA==",
       "license": "ISC"
     },
     "node_modules/lighthouse": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "csv-parser": "^3.2.0",
     "es-main": "^1.4.0",
     "express": "^5.2.1",
-    "lh-pptr-framework": "1.3.5",
+    "lh-pptr-framework": "1.3.6",
     "lighthouse": "^13.1.0",
     "logform": "^2.7.0",
     "mocha": "^11.3.0",


### PR DESCRIPTION
## Changes

- Bump `lh-pptr-framework` from `1.3.5` to `1.3.6` in root and `docker/v13.1.0/` — restores all custom audits/gatherers